### PR TITLE
登録した出欠回答の削除機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ https://nomishiro-bancho-2b23287ae884.herokuapp.com
 | 出欠表 |  |
 | --- | --- |
 | ![出欠回答画面](https://github.com/take0603/nomishiro-bancho/blob/images/attendance_new.png) | ![　出欠表表示画面](https://github.com/take0603/nomishiro-bancho/blob/images/attendance_show.png) |
-| URLを回答者に案内しアプリ上で回答をもらう<br>出欠表関連はログイン不要 | 全員の候補日ごとの回答一覧表示<br>回答登録・変更 |
+| URLを回答者に案内しアプリ上で回答をもらう<br>出欠表関連はログイン不要 | 全員の候補日ごとの回答一覧表示<br>回答登録・変更・削除 |
 
 | 支払表 |  |
 | --- | --- |

--- a/app/assets/stylesheets/attendance.scss
+++ b/app/assets/stylesheets/attendance.scss
@@ -112,6 +112,26 @@
   opacity: 0.6;
 }
 
+.attendance_options_area {
+  display: flex;
+  justify-content: space-between;
+}
+
+.attendance_delete_btn {
+  color: #000;
+  font-size: 0.9rem;
+  transition: 0.2s;
+}
+
+.attendance_delete_btn:hover {
+  opacity: 0.6;
+}
+
+.attendance_delete_btn i {
+  margin-right: 5px;
+
+}
+
 // show
 .attendance_title {
   border-bottom: 1px solid #dee2e6;

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -41,6 +41,13 @@ class AttendancesController < ApplicationController
     end
   end
 
+  def destroy
+    @member = Member.find(params[:member_id])
+    @member.destroy
+    flash[:notice] = "回答が削除されました。"
+    redirect_to event_attendances_path
+  end
+
   private
 
   def member_params

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,5 +1,5 @@
 class Member < ApplicationRecord
-  has_many :attendances
+  has_many :attendances, dependent: :destroy
   has_many :schedules, through: :attendances
 
   accepts_nested_attributes_for :attendances

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -32,8 +32,13 @@
       </ul>
       <%= f.submit "回答", class: "attendance_form_button" %>
     <% end %>
-    <%= link_to :back, class: "back" do %>
-      <i class="fa-solid fa-chevron-left fa-lg"></i>戻る
-    <% end %>
+    <div class="attendance_options_area">
+      <%= link_to :back, class: "back" do %>
+        <i class="fa-solid fa-chevron-left fa-lg"></i>戻る
+      <% end %>
+      <%= link_to event_attendances_path(params[:event_id], member_id: @member.id), data: { turbo_method: :delete, turbo_confirm: "登録した回答を削除しますか？" }, class: "attendance_delete_btn" do %>
+        <i class="fa-solid fa-trash" style="color: #757070;"></i>削除
+      <% end %>
+    </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   get '/mypage', to: 'home#mypage'
   get '/users/account', to: 'users#show'
   resources :events do
-    resource :attendances, only: [:show, :new, :create, :edit, :update]
+    resource :attendances, only: [:show, :new, :create, :edit, :update, :destroy]
     resources :payments
   end
 

--- a/spec/requests/attendances_spec.rb
+++ b/spec/requests/attendances_spec.rb
@@ -125,4 +125,21 @@ RSpec.describe "Attendances", type: :request do
       end
     end
   end
+
+  describe "DELETE #destroy" do
+    let(:user) { create(:user) }
+    let(:event) { create(:event, user: user) }
+    let(:schedule) { create(:schedule, event: event) }
+    let(:member) { create(:member) }
+    let!(:attendance) { create(:attendance, event: event, schedule: schedule, member: member) }
+
+    it "対象のメンバーを削除すること" do
+      expect { delete event_attendances_path(event, member_id: member.id) }.to change { Member.count }.by(-1)
+    end
+
+    it "当該出欠表の詳細画面に遷移すること" do
+      delete event_attendances_path(event, member_id: member.id)
+      expect(response).to redirect_to(event_attendances_path(event))
+    end
+  end
 end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -179,4 +179,20 @@ RSpec.describe "Attendances" do
       end
     end
   end
+
+  describe "出欠回答削除", js: true do
+    let(:user) { create(:user) }
+    let(:event) { create(:event, user: user) }
+    let(:schedule) { create(:schedule, event: event) }
+    let(:member) { create(:member) }
+    let!(:attendance) { create(:attendance, answer: "ok", event: event, schedule: schedule, member: member) }
+
+    it "削除ボタン押下で支払表を削除すること" do
+      visit event_attendances_path(event)
+      click_on member.member_name
+      click_on "削除"
+      page.accept_confirm
+      expect(page).to have_content("回答が削除されました。")
+    end
+  end
 end


### PR DESCRIPTION
各ユーザーが登録した、出欠の回答を編集ページから削除できる機能を追加しました。