### PR TITLE
新規登録、ログイン後のリダイレクト先をマイページに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ https://nomishiro-bancho-2b23287ae884.herokuapp.com
 | --- | --- |
 | フロントエンド | HTML, CSS, JavaScript, Bootstrap |
 | バックエンド | Ruby, Ruby on Rails |
-| インフラ | Heroku |
+| インフラ | Heroku, AWS(S3による外部ストレージ) |
 | DB | PostgreSQL |
 | 環境構築 | Docker, Docker Compose |
 | テスト | RuboCop<br>RSpec<br>- 単体テスト(model, Helper)<br>- 機能テスト(request)<br>- 統合テスト(system)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,10 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   before_action :ensure_normal_user, only: :destroy
 
+  def after_sign_up_path_for(resource)
+    mypage_path
+  end
+
   def ensure_normal_user
     if resource.email == 'guest@example.com'
       redirect_to root_path, alert: 'ゲストユーザーのためアカウントを削除できません。'

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,6 +2,10 @@ class Users::SessionsController < Devise::SessionsController
   def guest_sign_in
     user = User.guest
     sign_in user
-    redirect_to root_path, notice: 'ゲストユーザーとしてログインしました。'
+    redirect_to mypage_path, notice: 'ゲストユーザーとしてログインしました。'
+  end
+
+  def after_sign_in_path_for(resource)
+    mypage_path
   end
 end

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -114,10 +114,17 @@
     </div>
   </div>
   <div class="registration_reccomend">
-    <h2>幹事は嫌いですか？</h2>
-    <p>ユーザー登録をして管理を開始</p>
-    <%= link_to "ユーザー登録", new_user_registration_path %>
-    <span>または</span>
-    <%= link_to "ゲストログイン", users_guest_sign_in_path, data: { turbo_method: :post } %>
+    <% if user_signed_in? %>
+      <h2>ここからはじめましょう</h2>
+      <%= link_to "マイページ", mypage_path %>
+      <span>または</span>
+      <%= link_to "イベントを作成", new_event_path %>
+    <% else %>
+      <h2>幹事は嫌いですか？</h2>
+      <p>ユーザー登録をして管理を開始</p>
+      <%= link_to "ユーザー登録", new_user_registration_path %>
+      <span>または</span>
+      <%= link_to "ゲストログイン", users_guest_sign_in_path, data: { turbo_method: :post } %>
+    <% end %>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -24,7 +24,7 @@
               <i class="fa-solid fa-arrow-right-from-bracket me-2"></i>ログアウト
             <% end %>
           </div>
-        <% else %>  
+        <% else %>
           <div class="navbar-nav<%= " navbar-dark" if current_page?(root_path) %>">
             <%= link_to users_guest_sign_in_path, data: { turbo_method: :post }, class: "nav-link text-end" do %>
               <i class="fa-solid fa-person-walking-luggage me-2"></i>ゲストログイン

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    registrations: 'users/registrations'
+    registrations: 'users/registrations',
+    sessions: 'users/sessions'
   }
   devise_scope :user do
     post 'users/guest_sign_in', to: 'users/sessions#guest_sign_in'

--- a/spec/requests/users/sessions_controllers_spec.rb
+++ b/spec/requests/users/sessions_controllers_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Users::SessionsControllers", type: :request do
 
     it "トップページに遷移すること" do
       post users_guest_sign_in_path
-      expect(response.body).to redirect_to(root_path)
+      expect(response.body).to redirect_to(mypage_path)
     end
   end
 end

--- a/spec/system/homes_spec.rb
+++ b/spec/system/homes_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Homes", type: :system do
         click_on "ゲストログイン"
       end
       expect(page).to have_content("ゲストユーザーとしてログインしました。")
-      expect(page).to have_current_path(root_path)
+      expect(page).to have_current_path(mypage_path)
     end
 
     it "ヘッダーロゴ押下でトップページへ遷移すること" do

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Users", type: :system do
     it "ゲストログインボタン押下でゲストログインし、トップページへリダイレクトすること" do
       click_on "ゲストとしてお試しログイン"
       expect(page).to have_content("ゲストユーザーとしてログインしました。")
-      expect(page).to have_current_path(root_path)
+      expect(page).to have_current_path(mypage_path)
     end
 
     context "有効な値の場合" do
@@ -18,7 +18,7 @@ RSpec.describe "Users", type: :system do
         fill_in "確認用パスワード", with: "password"
         expect { click_on "ユーザー登録" }.to change { User.count }.by(1)
         expect(page).to have_content("アカウント登録が完了しました。")
-        expect(page).to have_current_path(root_path)
+        expect(page).to have_current_path(mypage_path)
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe "Users", type: :system do
     it "ゲストログインボタン押下でゲストログインし、トップページへリダイレクトすること" do
       click_on "ゲストとしてお試しログイン"
       expect(page).to have_content("ゲストユーザーとしてログインしました。")
-      expect(page).to have_current_path(root_path)
+      expect(page).to have_current_path(mypage_path)
     end
 
     context "有効な値の場合" do
@@ -52,7 +52,7 @@ RSpec.describe "Users", type: :system do
           click_on "ログイン"
         end
         expect(page).to have_content("ログインしました。")
-        expect(page).to have_current_path(root_path)
+        expect(page).to have_current_path(mypage_path)
       end
 
       it "ログイン後、ヘッダーメニューが正しく表示されること" do
@@ -83,7 +83,7 @@ RSpec.describe "Users", type: :system do
         click_on "ゲストログイン"
       end
       expect(page).to have_content("ゲストユーザーとしてログインしました。")
-      expect(page).to have_current_path(root_path)
+      expect(page).to have_current_path(mypage_path)
     end
   end
 


### PR DESCRIPTION
・トップページにリダイレクトしていたのをマイページに変更
・ログイン状態時、トップページの新規登録を促すリンクをマイページのリンクになるよう分岐